### PR TITLE
Set PATH in zip.cmd

### DIFF
--- a/zip.cmd
+++ b/zip.cmd
@@ -1,3 +1,4 @@
+SET PATH=%PATH%;"C:\Program Files\7-Zip"
 SET filename="FS22_manualAttach.zip"
 
 IF EXIST %filename% (


### PR DESCRIPTION
Set Path in the zip.cmd to fix "7z.exe is not recognized as internal or external command" error.